### PR TITLE
Add handling for config directory with .yml/.yaml extension

### DIFF
--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -1468,7 +1468,7 @@ class RailsConfig(BaseModel):
         """
         # If the config path is a file, we load the YAML content.
         # Otherwise, if it's a folder, we iterate through all files.
-        if config_path.endswith(".yaml") or config_path.endswith(".yml"):
+        if os.path.isfile(config_path) and (config_path.endswith(".yaml") or config_path.endswith(".yml")):
             with open(config_path) as f:
                 raw_config = yaml.safe_load(f.read())
 


### PR DESCRIPTION
## Description
Prevents a (probably mistakenly created) `config.yml/` directory from being attempted to open as a regular file, resulting in a misleading `PermissionError` (source: just happened to me).

**Before**: `PermissionError: [Errno 13] Permission denied: 'config.yml'`
**After**: `config.yml/` directory is treated as a valid config directory (falls through to existing directory handling logic).
